### PR TITLE
fix: null/unset initialText overwrites controller.text

### DIFF
--- a/lib/code_crafter/code_area.dart
+++ b/lib/code_crafter/code_area.dart
@@ -176,7 +176,7 @@ class _CodeCrafterState extends State<CodeCrafter> {
     _codeFocus = widget.focusNode ?? FocusNode();
     _hoverHorizontalScroll = ScrollController();
     _hoverVerticalSCroll = ScrollController();
-    widget.controller.text = widget.initialText ?? '';
+    if (widget.initialText != null) widget.controller.text = widget.initialText!;
     widget.controller.manualAiCompletion = getManualAiSuggestion;
     if (widget.lspConfig != null) {
       widget.lspConfig!.responses.listen((data) {


### PR DESCRIPTION
When setting `controller.text` from initState (before rendering the CodeCrafter widget), the text field isn't updated as it the text is overwritten to blank when the widget builds **even when there is no initial text passed**

This fixes that behaviour :)